### PR TITLE
fix: handle case for empty messages in lastMessage computation

### DIFF
--- a/src/components/shared/chats/ChatItem.tsx
+++ b/src/components/shared/chats/ChatItem.tsx
@@ -27,10 +27,11 @@ const ChatItem = ({
   )
   const lastMessage = useMemo(() => {
     const messages = selectableChatRoom?.messages ?? []
-    return messages[messages.length - 1]
+    return messages.length === 0 ? null : messages[messages.length - 1]
   }, [selectableChatRoom])
 
   const lastMessageAuthor = useMemo(() => {
+    if (lastMessage?.author_chat_id == null) return ''
     return (
       selectableChatRoom.members.find(
         member => member.$id === lastMessage.author_chat_id


### PR DESCRIPTION
This pull request includes a small but important fix in the `ChatItem` component to handle edge cases when there are no messages in a chat room.

* [`src/components/shared/chats/ChatItem.tsx`](diffhunk://#diff-434e645740bda849d3cac24aafc8fd2c179bdf508902381cced15a427bae36aeL30-R34): Updated the `lastMessage` computation to return `null` instead of potentially causing an error when the messages array is empty. Additionally, added a check to ensure `lastMessageAuthor` returns an empty string if `lastMessage.author_chat_id` is `null` or `undefined`.